### PR TITLE
Provides jvm-application-package instead of jvm-application

### DIFF
--- a/sbt/detect.go
+++ b/sbt/detect.go
@@ -24,6 +24,12 @@ import (
 	"github.com/buildpacks/libcnb"
 )
 
+const (
+	PlanEntrySBT                   = "sbt"
+	PlanEntryJVMApplicationPackage = "jvm-application-package"
+	PlanEntryJDK                   = "jdk"
+)
+
 type Detect struct{}
 
 func (Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error) {
@@ -40,12 +46,12 @@ func (Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error) 
 		Plans: []libcnb.BuildPlan{
 			{
 				Provides: []libcnb.BuildPlanProvide{
-					{Name: "jvm-application"},
-					{Name: "sbt"},
+					{Name: PlanEntryJVMApplicationPackage},
+					{Name: PlanEntrySBT},
 				},
 				Requires: []libcnb.BuildPlanRequire{
-					{Name: "jdk"},
-					{Name: "sbt"},
+					{Name: PlanEntryJDK},
+					{Name: PlanEntrySBT},
 				},
 			},
 		},

--- a/sbt/detect_test.go
+++ b/sbt/detect_test.go
@@ -60,7 +60,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 			Plans: []libcnb.BuildPlan{
 				{
 					Provides: []libcnb.BuildPlanProvide{
-						{Name: "jvm-application"},
+						{Name: "jvm-application-package"},
 						{Name: "sbt"},
 					},
 					Requires: []libcnb.BuildPlanRequire{


### PR DESCRIPTION
Changes name of provided plan entry to draw a distinction between a runnable JVM application (mostly process types) contributed by buildpacks like `paketo-buildpacks/executable-jar` and the packaged bytecode required as input to those buildpacks, provided by build system buildpacks like `paketo-buildpacks/sbt`.

Signed-off-by: Emily Casey <ecasey@vmware.com>
