### PR TITLE
Bump to using Go 1.17 and fix module declarations to have major version suffix

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -23,7 +23,7 @@ import (
 	"github.com/paketo-buildpacks/libpak"
 	"github.com/paketo-buildpacks/libpak/bard"
 
-	"github.com/paketo-buildpacks/sbt/sbt"
+	"github.com/paketo-buildpacks/sbt/v6/sbt"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module github.com/paketo-buildpacks/sbt
+module github.com/paketo-buildpacks/sbt/v6
 
-go 1.15
+go 1.17
 
 require (
 	github.com/buildpacks/libcnb v1.25.5
@@ -8,4 +8,25 @@ require (
 	github.com/paketo-buildpacks/libbs v1.13.0
 	github.com/paketo-buildpacks/libpak v1.58.0
 	github.com/sclevine/spec v1.4.0
+)
+
+require (
+	github.com/BurntSushi/toml v1.0.0 // indirect
+	github.com/Masterminds/semver/v3 v3.1.1 // indirect
+	github.com/creack/pty v1.1.17 // indirect
+	github.com/heroku/color v0.0.6 // indirect
+	github.com/imdario/mergo v0.3.12 // indirect
+	github.com/magiconair/properties v1.8.5 // indirect
+	github.com/mattn/go-colorable v0.1.2 // indirect
+	github.com/mattn/go-isatty v0.0.8 // indirect
+	github.com/mattn/go-shellwords v1.0.12 // indirect
+	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
+	github.com/paketo-buildpacks/libjvm v1.35.0 // indirect
+	github.com/pavel-v-chernykh/keystore-go/v4 v4.3.0 // indirect
+	github.com/pelletier/go-toml v1.9.4 // indirect
+	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
+	golang.org/x/net v0.0.0-20210726213435-c6fcb2dbf985 // indirect
+	golang.org/x/sys v0.0.0-20220207234003-57398862261d // indirect
+	golang.org/x/text v0.3.6 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -28,7 +28,6 @@ github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/heroku/color v0.0.6 h1:UTFFMrmMLFcL3OweqP1lAdp8i1y/9oHqkeHjQ/b/Ny0=
@@ -135,7 +134,6 @@ golang.org/x/tools v0.1.6-0.20210726203631-07bc1bf47fb2/go.mod h1:o0xws9oXOQQZyj
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=

--- a/sbt/build_test.go
+++ b/sbt/build_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/paketo-buildpacks/libbs"
 	"github.com/sclevine/spec"
 
-	"github.com/paketo-buildpacks/sbt/sbt"
+	"github.com/paketo-buildpacks/sbt/v6/sbt"
 )
 
 func testBuild(t *testing.T, context spec.G, it spec.S) {

--- a/sbt/detect_test.go
+++ b/sbt/detect_test.go
@@ -26,7 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/sclevine/spec"
 
-	"github.com/paketo-buildpacks/sbt/sbt"
+	"github.com/paketo-buildpacks/sbt/v6/sbt"
 )
 
 func testDetect(t *testing.T, context spec.G, it spec.S) {

--- a/sbt/distribution_test.go
+++ b/sbt/distribution_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/paketo-buildpacks/libpak"
 	"github.com/sclevine/spec"
 
-	"github.com/paketo-buildpacks/sbt/sbt"
+	"github.com/paketo-buildpacks/sbt/v6/sbt"
 )
 
 func testDistribution(t *testing.T, context spec.G, it spec.S) {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-GOOS="linux" go build -ldflags='-s -w' -tags osusergo -o bin/main github.com/paketo-buildpacks/sbt/cmd/main
+GOOS="linux" go build -ldflags='-s -w' -tags osusergo -o bin/main github.com/paketo-buildpacks/sbt/v6/cmd/main
 
 if [ "${STRIP:-false}" != "false" ]; then
   strip bin/main


### PR DESCRIPTION
## Summary

Bump to Go 1.17 and add major version to module path

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
