### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `gcr.io/paketo-buildpacks/sbt`
 
-The Paketo SBT Buildpack is a Cloud Native Buildpack that builds SBT-based applications from source.
+The Paketo Buildpack for SBT is a Cloud Native Buildpack that builds SBT-based applications from source.
 
 ## Behavior
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/sbt"
   id = "paketo-buildpacks/sbt"
   keywords = ["java", "sbt", "scala", "build-system"]
-  name = "Paketo SBT Buildpack"
+  name = "Paketo Buildpack for SBT"
   sbom-formats = ["application/vnd.cyclonedx+json", "application/vnd.syft+json"]
   version = "{{.version}}"
 


### PR DESCRIPTION
Renames 'Paketo SBT Buildpack' to 'Paketo Buildpack for SBT'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
