### PR TITLE
Do not use effect.NewExecutor use CommandExecutor instead

### DIFF
--- a/sbt/build.go
+++ b/sbt/build.go
@@ -107,7 +107,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 		InterestingFileDetector:  libbs.AlwaysInterestingFileDetector{},
 	}
 
-	sbomScanner := sbom.NewSyftCLISBOMScanner(context.Layers, effect.NewExecutor(), b.Logger)
+	sbomScanner := sbom.NewSyftCLISBOMScanner(context.Layers, effect.CommandExecutor{}, b.Logger)
 
 	a, err := b.ApplicationFactory.NewApplication(
 		map[string]interface{}{},

--- a/sbt/build_test.go
+++ b/sbt/build_test.go
@@ -17,7 +17,6 @@
 package sbt_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -43,12 +42,14 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 
-		ctx.Application.Path, err = ioutil.TempDir("", "build-application")
+		ctx.Application.Path, err = os.MkdirTemp("", "build-application")
 		Expect(err).NotTo(HaveOccurred())
 
-		ctx.Layers.Path, err = ioutil.TempDir("", "build-layers")
+		ctx.Layers.Path, err = os.MkdirTemp("", "build-layers")
 		Expect(err).NotTo(HaveOccurred())
 		sbtBuild = sbt.Build{ApplicationFactory: &FakeApplicationFactory{}}
+
+		t.Setenv("BP_ARCH", "amd64")
 	})
 
 	it.After(func() {
@@ -66,7 +67,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		it("sets the settings path", func() {
-			Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "sbt"), []byte{}, 0644)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "sbt"), []byte{}, 0644)).To(Succeed())
 			ctx.StackID = "test-stack-id"
 
 			result, err := sbtBuild.Build(ctx)
@@ -85,7 +86,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		it("sets the settings path", func() {
-			Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "sbt"), []byte{}, 0644)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "sbt"), []byte{}, 0644)).To(Succeed())
 			ctx.StackID = "test-stack-id"
 
 			result, err := sbtBuild.Build(ctx)
@@ -99,7 +100,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	it("does not contribute distribution if wrapper exists", func() {
-		Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "sbt"), []byte{}, 0644)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "sbt"), []byte{}, 0644)).To(Succeed())
 		ctx.StackID = "test-stack-id"
 
 		result, err := sbtBuild.Build(ctx)

--- a/sbt/detect_test.go
+++ b/sbt/detect_test.go
@@ -17,7 +17,6 @@
 package sbt_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -40,7 +39,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 
-		ctx.Application.Path, err = ioutil.TempDir("", "sbt")
+		ctx.Application.Path, err = os.MkdirTemp("", "sbt")
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -53,7 +52,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	it("passes with build.sbt", func() {
-		Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "build.sbt"), []byte{}, 0644))
+		Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "build.sbt"), []byte{}, 0644))
 
 		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
 			Pass: true,

--- a/sbt/distribution_test.go
+++ b/sbt/distribution_test.go
@@ -17,7 +17,6 @@
 package sbt_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -40,7 +39,7 @@ func testDistribution(t *testing.T, context spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 
-		ctx.Layers.Path, err = ioutil.TempDir("", "distribution-layers")
+		ctx.Layers.Path, err = os.MkdirTemp("", "distribution-layers")
 		Expect(err).NotTo(HaveOccurred())
 	})
 


### PR DESCRIPTION
## Summary
When running `syft`, do not use effect.NewExecutor which runs the command with a tty. This seems to cause an issue with syft (or possibly with our tty library pty), and in either case you end up with stray formatting characters even though we tell syft to be quiet. Using CommandExecutor is basically the same, but it doesn't run with a tty.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
